### PR TITLE
Set PrivateAssets=all for BuildTasks helper package ref

### DIFF
--- a/facebook/android/Facebook.Android.Binding/Facebook.Android.Binding.csproj
+++ b/facebook/android/Facebook.Android.Binding/Facebook.Android.Binding.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Maui.NativeLibraryInterop.BuildTasks" Version="$(NLIPackageVersion)" />
+    <PackageReference Include="CommunityToolkit.Maui.NativeLibraryInterop.BuildTasks" Version="$(NLIPackageVersion)" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/facebook/macios/Facebook.MaciOS.Binding/Facebook.MaciOS.Binding.csproj
+++ b/facebook/macios/Facebook.MaciOS.Binding/Facebook.MaciOS.Binding.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Maui.NativeLibraryInterop.BuildTasks" Version="$(NLIPackageVersion)" />
+    <PackageReference Include="CommunityToolkit.Maui.NativeLibraryInterop.BuildTasks" Version="$(NLIPackageVersion)" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/firebase/macios/Firebase.MaciOS.Binding/Firebase.MaciOS.Binding.csproj
+++ b/firebase/macios/Firebase.MaciOS.Binding/Firebase.MaciOS.Binding.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Maui.NativeLibraryInterop.BuildTasks" Version="$(NLIPackageVersion)" />
+    <PackageReference Include="CommunityToolkit.Maui.NativeLibraryInterop.BuildTasks" Version="$(NLIPackageVersion)" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/googlecast/macios/GoogleCast.MaciOS.Binding/GoogleCast.MaciOS.Binding.csproj
+++ b/googlecast/macios/GoogleCast.MaciOS.Binding/GoogleCast.MaciOS.Binding.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Maui.NativeLibraryInterop.BuildTasks" Version="$(NLIPackageVersion)" />
+    <PackageReference Include="CommunityToolkit.Maui.NativeLibraryInterop.BuildTasks" Version="$(NLIPackageVersion)" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/template/android/NewBinding.Android.Binding/NewBinding.Android.Binding.csproj
+++ b/template/android/NewBinding.Android.Binding/NewBinding.Android.Binding.csproj
@@ -28,6 +28,6 @@
 
   <!-- Reference to NuGet for building bindings -->
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Maui.NativeLibraryInterop.BuildTasks" Version="0.0.1-pre1" />
+    <PackageReference Include="CommunityToolkit.Maui.NativeLibraryInterop.BuildTasks" Version="0.0.1-pre1" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/template/macios/NewBinding.MaciOS.Binding/NewBinding.MaciOS.Binding.csproj
+++ b/template/macios/NewBinding.MaciOS.Binding/NewBinding.MaciOS.Binding.csproj
@@ -32,6 +32,6 @@
 
   <!-- Reference to NuGet for building bindings -->
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Maui.NativeLibraryInterop.BuildTasks" Version="0.0.1-pre1" />
+    <PackageReference Include="CommunityToolkit.Maui.NativeLibraryInterop.BuildTasks" Version="0.0.1-pre1" PrivateAssets="all" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes: https://github.com/CommunityToolkit/Maui.NativeLibraryInterop/issues/32

Ensures the BuildTasks helper package will not be transitive dependency of the binding projects.